### PR TITLE
Plausibleでのアクセス解析用にスクリプトを追加

### DIFF
--- a/book/source/_layouts/layout.html
+++ b/book/source/_layouts/layout.html
@@ -1,0 +1,5 @@
+{% extends template.self %}
+
+{% block head %}
+  <script defer data-domain="fintan-content.github.io,all.fintan" src=https://plausible.io/js/script.js></script>
+{% endblock %}


### PR DESCRIPTION
Plausibleでのアクセス解析用にスクリプトを追加しました。

リファレンスに[Themeの作成方法](https://honkit.netlify.app/themes/)について記載されていましたので、使用していた[デフォルトテーマ](https://github.com/honkit/honkit/blob/master/packages/%40honkit/theme-default/_layouts/layout.html)（何も指定していない）のコードを見て差し込めそうな箇所を確認し、カスタマイズしました。
